### PR TITLE
"Theme Developer" badge.

### DIFF
--- a/ReGuilded/badges.js
+++ b/ReGuilded/badges.js
@@ -17,6 +17,9 @@ module.exports.genBadgeGetter = defaultBadges =>
     function badges() {
         // Calls default badge getter
         let badges = defaultBadges.call(this)
+        // Checks if the user is theme developer
+        if (module.exports.members.theme_developers.includes(this.userInfo.id)) 
+            (badges ?? (badges = [])).push(module.exports.theme_developer)
         // Checks if the user is ReGuilded staff
         if(module.exports.members.staff.includes(this.userInfo.id))
             // Pushes the new badge
@@ -36,6 +39,17 @@ module.exports.staff = {
     tooltipText: 'ReGuilded staff',
     // Adds the display text/name
     text: 'ReGuilded',
+    style: { backgroundColor: '#10171F', color: '#CC5555' }
+}
+
+module.exports.theme_developer = {
+    icon: 'https://raw.githubusercontent.com/ReGuilded/ReGuilded/main/logo/ReGuilded.png',
+    // Sets the name of the badge for getting this badge
+    name: 'ThemeDeveloper',
+    // What is displayed when you hover over the badge
+    tooltipText: 'Theme developer',
+    // Adds the display text/name
+    text: 'Theme Developer',
     style: { backgroundColor: '#10171F', color: '#CC5555' }
 }
 /**

--- a/ReGuilded/managers/themesManager.js
+++ b/ReGuilded/managers/themesManager.js
@@ -95,15 +95,6 @@ module.exports = class ThemesManager extends ExtensionManager {
         }.bind(this), 3000)
 
     }
-    
-    /**
-     * Sends theme developers variable.
-     * @returns 
-     */
-
-    getThemeDevelopers() {
-        return this.themeDevelopers
-    }
 
     /**
      * Loads a ReGuilded theme

--- a/ReGuilded/managers/themesManager.js
+++ b/ReGuilded/managers/themesManager.js
@@ -21,6 +21,7 @@ module.exports = class ThemesManager extends ExtensionManager {
      */
     init(enabled = []) {
         // Gets a list of theme directories
+        const themeDevelopers = [];
         const themes = super.getDirs(enabled)
 
         // Gets every theme directory
@@ -35,6 +36,23 @@ module.exports = class ThemesManager extends ExtensionManager {
             const json = require(jsonPath)
             // Sets directory's name
             json.dirname = theme.name
+
+            // Check theme developers variable. This is used later on to give theme developers badges.
+            switch (typeof json.developers) {
+                case "string":
+                    themeDevelopers.push(json.developers);
+                    break;
+                case "object":
+                    if (Array.isArray(json.developers)) {
+                        themeDevelopers.concat(json.developers);
+                    } else {
+                        console.log(`Could not set badges on '${json.name}', because 'developers' is an object, but not an array.`)
+                    }
+                    break;
+                default:
+                    console.log(`Could not set badges on '${json.name}', because 'developers' is neither a string or object.`)
+                    break;
+            }
 
             // Gets ID property
             const propId = json.id
@@ -61,11 +79,30 @@ module.exports = class ThemesManager extends ExtensionManager {
             this.all.push(json)
         }
 
+        // Pushes themeDevelopers variable after removing duplicated IDs.
+        const noDuplicatedThemeDevelopers = [];
+
+        for (let developer of themeDevelopers) {
+            if (!noDuplicatedThemeDevelopers.includes(developer)) 
+                noDuplicatedThemeDevelopers.push(developer)
+        }
+        
+        this.themeDevelopers = noDuplicatedThemeDevelopers;
+
         // Wait 3 seconds to let Guilded's Styles load.
         setTimeout(function() {
             this.loadAll();
         }.bind(this), 3000)
 
+    }
+    
+    /**
+     * Sends theme developers variable.
+     * @returns 
+     */
+
+    getThemeDevelopers() {
+        return this.themeDevelopers
     }
 
     /**

--- a/scripts/preload/preload.js
+++ b/scripts/preload/preload.js
@@ -15,14 +15,16 @@ if (document.readyState === "loading") {
 }
 
 // Sets ReGuilded staff members
-fetch('https://gist.githubusercontent.com/IdkGoodName/feb175e9d74320cb61a72bf2ad60fc81/raw/b9fd6edd73da1634530872b407ed7ec123453ce2/staff.json')
+fetch(`https://gist.githubusercontent.com/IdkGoodName/feb175e9d74320cb61a72bf2ad60fc81/raw/b9fd6edd73da1634530872b407ed7ec123453ce2/staff.json?v=${Date.now()}&t=${Math.random().toString(36).substring(2, 15)}`)
     .then(x => x.json())
     .then(x => badges.members.staff = x)
 
 document.addEventListener('readystatechange', () => {
     // When bundle loads
     if(document.readyState === 'interactive') {
-        global.bundle.addEventListener('load', () => {
+        global.bundle.addEventListener('load', async () => {
+            badges.members.theme_developers = global.ReGuilded.themesManager.getThemeDevelopers()
+
             // FIXME: NO SVGS ANYMORE BECAUSE OF THIS
             // Push a new module to it
             global.webpackJsonp.push([ [151], { 1393:

--- a/scripts/preload/preload.js
+++ b/scripts/preload/preload.js
@@ -23,7 +23,8 @@ document.addEventListener('readystatechange', () => {
     // When bundle loads
     if(document.readyState === 'interactive') {
         global.bundle.addEventListener('load', async () => {
-            badges.members.theme_developers = global.ReGuilded.themesManager.getThemeDevelopers()
+            badges.members.theme_developers = global.ReGuilded.themesManager.themeDevelopers
+console.log(badges.members.theme_developers)
 
             // FIXME: NO SVGS ANYMORE BECAUSE OF THIS
             // Push a new module to it


### PR DESCRIPTION
I pushed an update where you can push a "developers" variable to theme.json ( like https://github.com/ReGuilded/ReGuilded/blob/main/_Settings/themes/Dream%20Frame/theme.json ) to give them a "theme developer" badge.

Also, I added a minor update that fetching the Reguilded Staff badge list won't get stuck by cache if changed.