### PR TITLE
Made Guilded Restart on Injection on windows and posibly on mac/linux

### DIFF
--- a/inject/index.js
+++ b/inject/index.js
@@ -47,8 +47,11 @@ async function mainAsync() {
             exec(platformModule.closeGuilded);
             // Executes the task
             await main[taskArg](platformModule.getAppDir(), reguildedPath)
+            logger.info("Relaunching Guilded(If not opened in 10 minutes after this please manually execute the app)");
+            //Open the app Again after the injection task is done
+            exec(platformModule.openGuilded);
             // Tells us that it succeeded
-            logger.info("Task", taskArg, "has been successful");
+            logger.info("Task", taskArg, "has been successful press ctrl + c to close this"); //critcal code bug causes this to hang on windows so we have to close it manually and tell the user to do so
         } catch(err) {
             logger.error("Failed to do task", taskArg);
             logger.fatal(err);

--- a/inject/platforms/darwin.js
+++ b/inject/platforms/darwin.js
@@ -1,5 +1,6 @@
 const { join } = require("path");
 
 exports.getAppDir = () => "/Applications/Guilded.app/Contents/Resources/app";
-
+exports.getAppPath = "/Applications/Guilded.app";
 exports.closeGuilded = "killall Guilded";
+exports.openGuilded = "open " + this.getExecPath;

--- a/inject/platforms/linux.js
+++ b/inject/platforms/linux.js
@@ -1,5 +1,7 @@
 const { join } = require("path");
 
 exports.getAppDir = () => join("/opt/Guilded", "resources/app");
+exports.getExecPath = "/opt/Guilded/guilded";
 
 exports.closeGuilded = "killall guilded";
+exports.openGuilded =  this.getExecPath + "& disown";

--- a/inject/platforms/win32.js
+++ b/inject/platforms/win32.js
@@ -1,5 +1,8 @@
 const { join } = require("path");
 
 exports.getAppDir = () => join(process.env.LOCALAPPDATA, "Programs/Guilded/resources/app");
+exports.getAppName = () => "Guilded";
+exports.getExecPath = process.env.LOCALAPPDATA + "/Programs/Guilded/Guilded.exe";
 
 exports.closeGuilded = "taskkill /f /IM Guilded.exe >nul";
+exports.openGuilded = "start " +this.getExecPath;


### PR DESCRIPTION
Added a restart feature on inject to ease the install for when we update the main installer to the new version 