### PR TITLE
Fixed possible issue with grabbing wrong asset to download off GitHub

### DIFF
--- a/src/preload/update.ts
+++ b/src/preload/update.ts
@@ -5,11 +5,10 @@ import { join } from "path";
 
 
 export default async function handleUpdate(updateInfo: VersionJson) {
-    const downloadUrl = updateInfo.assets[0].browser_download_url;
+    const downloadUrl = updateInfo.assets.find(x => x.name === "reguilded.asar").browser_download_url;
     const downloadPath = join(__dirname);
 
     return new Promise<boolean>(resolve => {
-
         try {
             stream(downloadUrl)
                 .pipe(createWriteStream(downloadPath))


### PR DESCRIPTION
- Realized when working on the installer we attempt to grab the first array item instead of directly grabbing the reguilded.asar