### PR TITLE
Fix Rollup importing binary node files

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -114,7 +114,7 @@ const config = [
             commonjs(),
             resolve({
                 browser: false,
-                resolveOnly: resolvableModules,
+                resolveOnly: module => module.match(resolvableModules) && !module.includes(".node"),
                 ignoreDynamicRequires: true
             }),
             configuredPlugins.json,


### PR DESCRIPTION
Fixes the issue referenced in the ReGuilded support forum:

"Weird characters being read as Javascript code? Pastebin: https://pastebin.com/fFGBwYVP"

This issue was being caused by Rollup attempting to include binary `.node` files which cannot be read properly. This PR fixes this issue and prevents Rollup from importing any file including `.node` within its filename.