### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ Our Patcher code is influence by [Powercord's Patcher Code](https://github.com/p
 
 ## License
 
-ReGuilded is licensed under the [BSD 3-Clause](https://github.com/ReGuilded/ReGuilded/blob/main/LICENSE) license.
+ReGuilded is licensed under the [MPL 2.0](https://github.com/ReGuilded/ReGuilded/blob/main/LICENSE) license.


### PR DESCRIPTION
In the [License section](https://github.com/ReGuilded/ReGuilded#license) of the README.md, it still listed the License as the BSD 3-Clause License, even though the license was changed to MPL 2.0.

I just decided to fix the typo.